### PR TITLE
allow vim to open filenames with spaces

### DIFF
--- a/bash_tricks.sh
+++ b/bash_tricks.sh
@@ -120,7 +120,7 @@ vim () {
         line_number=$(echo $* | awk -F: '{print $(NF-1)}')
         /usr/bin/vim +${line_number} ${*%:${line_number}:}
     else
-        /usr/bin/vim $*
+        /usr/bin/vim "$@"
     fi
 }
 


### PR DESCRIPTION
Positional parameters are complicated. It turns out that if you just use `$*`, quotes get stripped, and so vim ends up getting multiple arguments when you ask it to open a single file with spaces in its name.

The fix appears to be to use `"$@"`, as it passes on parameters "intact, without interpretation or expansion"[1].

[1] http://www.tldp.org/LDP/abs/html/internalvariables.html#APPREF
